### PR TITLE
Add support for fuzzy searching, result grouping and labelling, and relevance ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,17 @@ Property | Description
 
 ### Record handler
 
-Each search handler may also provide a result handler to finely tune how you wish to display or filter the results. At its most simplest, the record handler simply expects an array to be returned for each record that contains 4 properties:
+Each search handler may also provide a result handler to finely tune how you wish to display or filter the results. At its most simplest, the record handler simply expects an array to be returned for each record that contains 3 properties:
 
 - `title`: The title of the result.
-- `image`: The path to a corresponding image for the result.
 - `description`: Additional context for the result.
 - `url`: The URL that the result will point to.
+
+It may also optionally provide the following properties to provide more context:
+
+- `group`: The group that this result belongs to, when using grouped results.
+- `label`: The label of the result, which may provide more context or grouping for results.
+- `image`: The path to a corresponding image for the result.
 
 You may, of course, define additional properties in your array.
 

--- a/behaviors/Searchable.php
+++ b/behaviors/Searchable.php
@@ -10,7 +10,7 @@ use Winter\Storm\Support\Arr;
 use Winter\Storm\Support\Facades\Config;
 use Winter\Storm\Database\Traits\SoftDelete;
 use Illuminate\Support\Collection as BaseCollection;
-use Laravel\Scout\Builder;
+use Winter\Search\Classes\Builder;
 use Laravel\Scout\Scout;
 use Laravel\Scout\Searchable as BaseSearchable;
 
@@ -133,7 +133,7 @@ class Searchable extends ExtensionBase
      *
      * @param  string  $query
      * @param  \Closure  $callback
-     * @return \Laravel\Scout\Builder
+     * @return \Winter\Search\Classes\Builder
      */
     public static function search($query = '', $callback = null)
     {
@@ -154,7 +154,7 @@ class Searchable extends ExtensionBase
      *
      * @param  string  $query
      * @param  \Closure  $callback
-     * @return \Laravel\Scout\Builder
+     * @return \Winter\Search\Classes\Builder
      */
     public function doSearch($query = '', $callback = null)
     {
@@ -227,7 +227,7 @@ class Searchable extends ExtensionBase
     /**
      * Get the requested models from an array of object IDs.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  array  $ids
      * @return mixed
      */
@@ -239,7 +239,7 @@ class Searchable extends ExtensionBase
     /**
      * Get a query builder for retrieving the requested models from an array of object IDs.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  array  $ids
      * @return mixed
      */

--- a/behaviors/halcyon/Searchable.php
+++ b/behaviors/halcyon/Searchable.php
@@ -3,7 +3,7 @@
 namespace Winter\Search\Behaviors\Halcyon;
 
 use Cms\Classes\Theme;
-use Laravel\Scout\Builder;
+use Winter\Search\Classes\Builder;
 use Illuminate\Support\Collection as BaseCollection;
 use Winter\Search\Behaviors\Searchable as BaseSearchable;
 use Winter\Search\Classes\HalcyonModelObserver;
@@ -70,7 +70,7 @@ class Searchable extends BaseSearchable
     /**
      * Get the requested models from an array of object IDs.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  array  $ids
      * @return mixed
      */
@@ -82,7 +82,7 @@ class Searchable extends BaseSearchable
     /**
      * Get a query builder for retrieving the requested models from an array of object IDs.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  array  $ids
      * @return mixed
      */

--- a/classes/Builder.php
+++ b/classes/Builder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Winter\Search\Classes;
+
+use Laravel\Scout\Builder as BaseBuilder;
+
+class Builder extends BaseBuilder
+{
+    public function getWithRelevance(?callable $relevanceCalculator = null)
+    {
+        $collection = $this->engine()->get($this);
+
+        $relevanceCalculator = $relevanceCalculator ?? \Closure::fromCallable([$this, 'relevanceCalculator']);
+
+        return $collection->map(function ($model) use ($relevanceCalculator) {
+            $model->relevance = $relevanceCalculator($model, $this->query);
+            return $model;
+        })->sortByDesc('relevance');
+    }
+
+    public function firstWithRelevance(?callable $relevanceCalculator = null)
+    {
+        $collection = $this->engine()->get($this);
+
+        $relevanceCalculator = $relevanceCalculator ?? \Closure::fromCallable([$this, 'relevanceCalculator']);
+
+        return $collection->map(function ($model) use ($relevanceCalculator) {
+            $model->relevance = $relevanceCalculator($model, $this->query);
+            return $model;
+        })->sortByDesc('relevance')->first();
+    }
+
+    /**
+     * Calculates the relevance of a model to a query.
+     *
+     * @param \Winter\Storm\Database\Model|\Winter\Storm\Halcyon\Model $model
+     * @param string $query
+     * @return float|int
+     */
+    public function relevanceCalculator($model, $query)
+    {
+        // Get ranking map
+        $rankingMap = $this->getRankingMap($model);
+
+        $relevance = 0;
+
+        foreach ($rankingMap as $field => $rank) {
+            if (stripos($model->{$field}, $query) !== false) {
+                // Count matches and multiply by rank
+                $relevance += substr_count(strtolower($model->{$field}), strtolower($query)) * $rank;
+            }
+        }
+
+        return $relevance;
+    }
+
+    /**
+     * Gets a ranking map of the searchable fields.
+     *
+     * Searchable fields are ordered by descending importance, with the most important field first. It applies ranking
+     * based on a double sequence.
+     *
+     * If no searchable fields are provided, this will return `false`.
+     *
+     * @return int[]|false
+     */
+    protected function getRankingMap($model)
+    {
+        if (!$model->propertyExists('searchable')) {
+            return false;
+        }
+
+        $searchable = array_reverse($model->searchable);
+        $rankingMap = [];
+        $rank = 1;
+
+        foreach ($searchable as $field) {
+            $rankingMap[$field] = $rank;
+            $rank *= 2;
+        }
+
+        return array_reverse($rankingMap, true);
+    }
+}

--- a/classes/Builder.php
+++ b/classes/Builder.php
@@ -18,7 +18,7 @@ class Builder extends BaseBuilder
         })->sortByDesc('relevance');
     }
 
-    public function firstWithRelevance(?callable $relevanceCalculator = null)
+    public function firstRelevant(?callable $relevanceCalculator = null)
     {
         $collection = $this->engine()->get($this);
 

--- a/components/Search.php
+++ b/components/Search.php
@@ -204,6 +204,15 @@ class Search extends ComponentBase
         $totalCount = 0;
         $totalTotal = 0;
 
+        $processedQuery = $this->processQuery($query);
+        if (empty($processedQuery)) {
+            return [
+                '#' . $this->getId('results') => $this->renderPartial('@no-query'),
+                'results' => [],
+                'count' => 0,
+            ];
+        }
+
         foreach ($handlers as $id => $handler) {
             $class = $handler['model'];
             if (is_string($class)) {
@@ -214,10 +223,11 @@ class Search extends ComponentBase
                     sprintf('Model for handler "%s" must be a database or Halcyon model, or a callback', $id)
                 );
             }
+
             if (is_callable($class)) {
-                $results = $class()->doSearch($this->processQuery($query))->getWithRelevance();
+                $results = $class()->doSearch($processedQuery)->getWithRelevance();
             } else {
-                $results = $class->doSearch($this->processQuery($query))->getWithRelevance();
+                $results = $class->doSearch($processedQuery)->getWithRelevance();
             }
 
             if ($results->count() === 0) {

--- a/components/Search.php
+++ b/components/Search.php
@@ -190,9 +190,9 @@ class Search extends ComponentBase
                 );
             }
             if (is_callable($class)) {
-                $results = $class()->doSearch($query)->paginate($this->property('perPage', 20), 'page', ($handlerPage === $id) ? $page : 1);
+                $results = $class()->doSearch($query)->getWithRelevance()->paginate($this->property('perPage', 20), 'page', ($handlerPage === $id) ? $page : 1);
             } else {
-                $results = $class->doSearch($query)->paginate($this->property('perPage', 20), 'page', ($handlerPage === $id) ? $page : 1);
+                $results = $class->doSearch($query)->getWithRelevance()->paginate($this->property('perPage', 20), 'page', ($handlerPage === $id) ? $page : 1);
             }
 
             if ($results->count() === 0) {

--- a/components/search/results.htm
+++ b/components/search/results.htm
@@ -14,12 +14,44 @@
 </ul>
 
 <ul class="results">
-    {% for result in results[selectedHandler].results %}
-    <li>
-        <a href="{{ result.url }}">
-            {{ result.title }}
-        </a><br>
-        <small>{{ result.description }}</small>
-    </li>
-    {% endfor %}
+    {% if __SELF__.isGrouped %}
+        {% for group, results in results[selectedHandler].results %}
+        <li>
+            <strong>{{ group }}</strong>
+            <ul>
+                {% for result in results %}
+                <li>
+                    {% if result.label %}
+                        <span class="label">{{ result.label }}</span><br>
+                    {% endif %}
+
+                    <a href="{{ result.url }}">
+                        {{ result.title }}
+                    </a><br>
+
+                    {% if __SELF__.showExcerpts %}
+                        <small>{{ result.description }}</small>
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    {% else %}
+        {% for result in results[selectedHandler].results %}
+        <li>
+            {% if result.label %}
+                <span class="label">{{ result.label }}</span><br>
+            {% endif %}
+
+            <a href="{{ result.url }}">
+                {{ result.title }}
+            </a><br>
+
+            {% if __SELF__.showExcerpts %}
+                <small>{{ result.description }}</small>
+            {% endif %}
+        </li>
+        {% endfor %}
+    {% endif %}
 </ul>

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require": {
         "php": "^8.0",
         "composer/installers": "~1.0",
-        "laravel/scout": "^9.4.5"
+        "laravel/scout": "^9.4.5",
+        "teamtnt/tntsearch": "^4.0"
     },
     "suggest": {
         "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",

--- a/database/factories/SearchableModelFactory.php
+++ b/database/factories/SearchableModelFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Winter\Search\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Winter\Search\Tests\Fixtures\SearchableModel;
+
+class SearchableModelFactory extends Factory
+{
+    protected $model = SearchableModel::class;
+
+    public function definition()
+    {
+        $faker = fake();
+        $faker->addProvider(\Faker\Provider\en_US\Text::class);
+
+        return [
+            'title' => $faker->sentence(),
+            'description' => $faker->sentence(30),
+            'content' => $faker->paragraph(16),
+            'keywords' => $faker->words(8, true),
+        ];
+    }
+}

--- a/engines/CollectionEngine.php
+++ b/engines/CollectionEngine.php
@@ -2,16 +2,16 @@
 
 namespace Winter\Search\Engines;
 
-use Arr;
 use Laravel\Scout\Engines\CollectionEngine as BaseCollectionEngine;
 use Winter\Storm\Database\Traits\SoftDelete;
+use Winter\Storm\Support\Arr;
 
 class CollectionEngine extends BaseCollectionEngine
 {
     /**
      * Ensure that soft delete handling is properly applied to the query.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  \Illuminate\Database\Query\Builder  $query
      * @return \Illuminate\Database\Query\Builder
      */

--- a/engines/DatabaseEngine.php
+++ b/engines/DatabaseEngine.php
@@ -2,21 +2,21 @@
 
 namespace Winter\Search\Engines;
 
-use Arr;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\DatabaseEngine as BaseDatabaseEngine;
 use Winter\Storm\Database\Traits\SoftDelete;
+use Winter\Storm\Support\Arr;
 
 class DatabaseEngine extends BaseDatabaseEngine
 {
     /**
      * Ensure that soft delete handling is properly applied to the query.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  \Illuminate\Database\Query\Builder  $query
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function ensureSoftDeletesAreHandled($builder, $query)
+    protected function constrainForSoftDeletes($builder, $query)
     {
         if (Arr::get($builder->wheres, '__soft_deleted') === 0) {
             return $query->withoutTrashed();
@@ -36,7 +36,7 @@ class DatabaseEngine extends BaseDatabaseEngine
      * Since Winter adds Scout capabilities through behaviours, we have no way to support the
      * attributes method of defining columns.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @param  string  $attributeClass
      * @return array
      */
@@ -51,7 +51,7 @@ class DatabaseEngine extends BaseDatabaseEngine
      * Since Winter adds Scout capabilities through behaviours, we have no way to support the
      * attributes method of defining columns.
      *
-     * @param  \Laravel\Scout\Builder  $builder
+     * @param  \Winter\Search\Classes\Builder  $builder
      * @return array
      */
     protected function getFullTextOptions(Builder $builder)

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -24,6 +24,14 @@ return [
                 'description' => 'Select search handlers that have been registered through a plugin\'s "registerSearchHandlers" method. You may select more than one.',
                 'placeholder' => 'Select one or more',
             ],
+            'fuzzySearch' => [
+                'title' => 'Fuzzy search?',
+                'description' => 'Allows the search query to match records more loosely. Some index providers may already provide fuzzy searching, so only enable this if necessary.',
+            ],
+            'orderByRelevance' => [
+                'title' => 'Order by relevance?',
+                'description' => 'Runs a custom relevance algorithm on results and orders based on relevancy. This is recommended only for database or collection search indexes, as other providers have their own relevance algorithms.',
+            ],
             'showExcerpts' => [
                 'title' => 'Show excerpts?',
                 'description' => 'If checked, excerpts from the result content will be displayed in search results.',
@@ -43,8 +51,8 @@ return [
                 'description' => 'If enabled, results will be grouped by logical groupings, such as categories or pages.',
             ],
             'perGroup' => [
-                'title' => 'Number of results per group',
-                'description' => 'Define the amount of results you wish to retrieve per group. Set to 0 to have no limit.',
+                'title' => 'Results per group',
+                'description' => 'Define the upper limit of results you wish to retrieve per group. Set to 0 to have no limit.',
                 'validationMessage' => 'Results per group must be a number',
             ],
         ],

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -8,6 +8,7 @@ return [
     'otherPlugins' => [
         'cmsPages' => 'CMS Pages',
         'staticPages' => 'Static Pages',
+        'winterBlog' => 'Winter Blog',
     ],
     'components' => [
         'search' => [
@@ -16,11 +17,16 @@ return [
             'groups' => [
                 'pagination' => 'Pagination',
                 'display' => 'Display',
+                'grouping' => 'Result grouping',
             ],
             'handler' => [
                 'title' => 'Search handlers',
                 'description' => 'Select search handlers that have been registered through a plugin\'s "registerSearchHandlers" method. You may select more than one.',
                 'placeholder' => 'Select one or more',
+            ],
+            'showExcerpts' => [
+                'title' => 'Show excerpts?',
+                'description' => 'If checked, excerpts from the result content will be displayed in search results.',
             ],
             'limit' => [
                 'title' => 'Results limit',
@@ -32,20 +38,14 @@ return [
                 'description' => 'Define the amount of results you wish to retrieve per page. Set to 0 to have no pagination.',
                 'validationMessage' => 'Results per page must be a number',
             ],
-            'combineResults' => [
-                'title' => 'Combine results',
-                'description' => 'If multiple search handlers are included, ticking this will combine the results into one result array. Otherwise, the results array will be grouped by the search handler name.',
+            'grouping' => [
+                'title' => 'Enable grouping?',
+                'description' => 'If enabled, results will be grouped by logical groupings, such as categories or pages.',
             ],
-            'displayImages' => [
-                'title' => 'Show images',
-            ],
-            'displayHandlerName' => [
-                'title' => 'Show search handler name',
-                'description' => 'Useful if you have combined results and wish to show the handler that provided the result',
-            ],
-            'displayPluginName' => [
-                'title' => 'Show plugin name',
-                'description' => 'Useful if you have combined results and wish to show the plugin that provided the result',
+            'perGroup' => [
+                'title' => 'Number of results per group',
+                'description' => 'Define the amount of results you wish to retrieve per group. Set to 0 to have no limit.',
+                'validationMessage' => 'Results per group must be a number',
             ],
         ],
     ],

--- a/tests/cases/models/SearchableModelTest.php
+++ b/tests/cases/models/SearchableModelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Winter\Search\Tests\Cases\Models;
+
+use System\Tests\Bootstrap\PluginTestCase;
+use Winter\Search\Tests\Fixtures\SearchableModel;
+
+class SearchableModelTest extends PluginTestCase
+{
+    public function testSearchWithRelevance()
+    {
+        SearchableModel::truncate();
+        $records = SearchableModel::factory()->count(50)->create();
+
+        // Second most relevant
+        $records[0]->update(['title' => 'TestQuery TestQuery TestQuery']);
+        // Third most relevant
+        $records[1]->update(['title' => 'TestQuery TestQuery']);
+        // Fourth most relevant
+        $records[2]->update(['description' => 'TestQuery TestQuery TestQuery']);
+        // Fifth most relevant
+        $records[3]->update(['description' => 'TestQuery TestQuery']);
+        // Most relevant
+        $records[4]->update(['title' => 'TestQuery TestQuery TestQuery', 'description' => 'TestQuery TestQuery TestQuery']);
+
+        $results = SearchableModel::search('TestQuery')->getWithRelevance();
+
+        $recordIds = $records->slice(0, 5)->pluck('id')->toArray();
+        $resultIds = $results->slice(0, 5)->pluck('id')->toArray();
+
+        $this->assertEquals($recordIds[4], $resultIds[0]);
+        $this->assertEquals($recordIds[0], $resultIds[1]);
+        $this->assertEquals($recordIds[1], $resultIds[2]);
+        $this->assertEquals($recordIds[2], $resultIds[3]);
+        $this->assertEquals($recordIds[3], $resultIds[4]);
+
+        $result = SearchableModel::search('TestQuery')->firstWithRelevance();
+
+        $this->assertEquals($recordIds[4], $result->id);
+    }
+}

--- a/tests/cases/models/SearchableModelTest.php
+++ b/tests/cases/models/SearchableModelTest.php
@@ -34,7 +34,7 @@ class SearchableModelTest extends PluginTestCase
         $this->assertEquals($recordIds[2], $resultIds[3]);
         $this->assertEquals($recordIds[3], $resultIds[4]);
 
-        $result = SearchableModel::search('TestQuery')->firstWithRelevance();
+        $result = SearchableModel::search('TestQuery')->firstRelevant();
 
         $this->assertEquals($recordIds[4], $result->id);
     }

--- a/tests/fixtures/SearchableModel.php
+++ b/tests/fixtures/SearchableModel.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Winter\Search\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Winter\Search\Behaviors\Searchable;
+use Winter\Search\Database\Factories\SearchableModelFactory;
+use Winter\Storm\Database\Model;
+use Winter\Storm\Database\Traits\ArraySource;
+
+class SearchableModel extends Model
+{
+    use ArraySource;
+    use HasFactory;
+
+    public $implement = [
+        Searchable::class,
+    ];
+
+    public $fillable = [
+        'title',
+        'description',
+        'content',
+        'keywords',
+    ];
+
+    public $searchable = [
+        'title',
+        'description',
+        'keywords',
+        'content',
+    ];
+
+    public $recordSchema = [
+        'title' => 'string',
+        'description' => 'string',
+        'content' => 'text',
+        'keywords' => 'string',
+    ];
+
+    protected static function newFactory()
+    {
+        return SearchableModelFactory::new();
+    }
+}


### PR DESCRIPTION
This PR brings in the following features:

### Fuzzy searching

Database and Collection indexes in Laravel Scout do not apply any sort of fuzzy searching, and thus tend to be very conservative in the results provided for a given query, especially if the query uses more than one word.

To allow for more results with these types of indexes, the Search component now provides a "Fuzzy search" property, which can be ticked. When ticked, the search query will be pre-processed to make it more fuzzy, which includes the following:

- Strips punctuation from the query.
- Removes any stop words, such as "it", "the", "can", etc.
- [Stems](https://en.wikipedia.org/wiki/Stemming) each word in the query, so words with the incorrect inflection or pluralisation can still be found.
- Replaces spacing with percentages, in order to allow words that aren't next to each other to be found.
- Trims the query.

This may provide more results for any given query, with a slight penalty for relevance.

This should be avoided on any index engine that provides its own fuzzy searching capabilities, such as Algolia or Meilisearch.

### Result grouping and labelling

The search plugin now allows results to be grouped, and to have labels to decorate the result. Both can be used to contextualise the results.

When using the Search component, you may enable result grouping to provide results in groups by ticking the "Enable grouping?" property. You can also limit the amount of results to display in each group. This can, for example, allow you to only show a certain number of pages in a section of pages so that different sections can be shown in the list of results earlier.

### Relevance ordering

By default, results in the Search plugin are not ordered in any particular way to account for the relevancy of the result. While this may be fine in cases where you are using index engines like Algolia or Meilisearch, which have their own relevancy algorithms (or can be configured as such), this may affect the results when using the Database and Collection index engines, which have no relevancy system.

In order to support a level of relevancy in these engines, results can be post-processed after being retrieved from the index to assign a relevancy score. Relevancy in this system is determined by the order of the property names in the `$searchable` definition for the index.

For example, with the below definition:

```php
public $searchable = [
    'title',
    'description',
    'keywords',
];
```

The `title` field will be the most relevant field, followed by the `description` and then `keywords`. A match in the `title` is given greater weight than a match in the `description`, which is given more weight than a match in the `keywords`.

The relevancy scoring also takes into account the words used in the query. For example, if the query `install winter cms` was used, the word `install` is given more weight than `winter`, which is then given more weight than the word `cms`.

To enable result relevancy, you may call the `getWithRelevance()` or `firstRelevant()` methods following any search:

```php
$results = \Acme\Blog\BlogSearch::doSearch('install winter cms')->getWithRelevance();
```

`getWithRelevance()` will retrieve all records, ordered by relevancy score, whilst `firstRelevant()` will retrieve only the most relevant record.

If you wish to customise the relevancy scoring, you may also provide a callable to both methods. The callable must accept two arguments, a model instance, and an array of words from the query, and return a score as a `float` or an `int`, which will be used to order the results descendingly (higher score = more relevant). Each record found in the index will be run through this callable.

```php
$results = \Acme\Blog\BlogSearch::doSearch('install winter cms')->getWithRelevance(function ($model, array $words) {
    // Score each record and return score as a integer or float.
});
```